### PR TITLE
Updated FileInfo.xml with FileInfo.ToString() correction and clarification

### DIFF
--- a/xml/System.IO/FileInfo.xml
+++ b/xml/System.IO/FileInfo.xml
@@ -2506,7 +2506,7 @@ The following example demonstrates moving a file to a different location and ren
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns the path as a string. Use the <see cref="P:System.IO.FileInfo.Name" /> property for the full path.</summary>
+        <summary>Returns the path as a string. The path returned represents what was passed to the <xref:System.IO.FileInfo> constructor.</summary>
         <returns>A string representing the path.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
## Fixed an error with the FileInfo.ToString() method description.

The recommendation to "Use the <see cref="P:System.IO.FileInfo.Name" /> property for the full path." is incorrect. `FileInfo.Name` returns ONLY the file name without parent path information.

Since there is an important note below that details the other options for getting file path information, I thought that this section should only pertain to what the ToString() method returns. If users need otherwise, they can continue reading the documentation below to discover these other options.